### PR TITLE
Add some additional features to administrate-field-ckeditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ ATTRIBUTE_TYPES = [
 ]
 ```
 
+Or with ckeditor options:
+```ruby
+ATTRIBUTE_TYPES = [
+  quxes: Field::Ckeditor.with_options({ckeditor: {uiColor: '#800000'}}),
+]
+```
+
 [Ckeditor]: https://github.com/galetahub/ckeditor
 [Administrate]: https://github.com/thoughtbot/administrate
 

--- a/administrate-field-ckeditor.gemspec
+++ b/administrate-field-ckeditor.gemspec
@@ -1,10 +1,8 @@
 $:.push File.expand_path("../lib", __FILE__)
 
-require "administrate/field/ckeditor"
-
 Gem::Specification.new do |gem|
   gem.name = "administrate-field-ckeditor"
-  gem.version = Administrate::Field::Ckeditor::VERSION
+  gem.version = "0.0.2"
   gem.authors = ["Rikki Pitt"]
   gem.email = ["rikkipitt@gmail.com"]
   gem.homepage = "https://github.com/jemcode/administrate-field-ckeditor"

--- a/app/views/fields/ckeditor/_form.html.erb
+++ b/app/views/fields/ckeditor/_form.html.erb
@@ -2,5 +2,5 @@
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.cktext_area field.attribute %>
+  <%= f.cktext_area field.attribute, ckeditor: field.ckeditor_options %>
 </div>

--- a/app/views/fields/ckeditor/_index.html.erb
+++ b/app/views/fields/ckeditor/_index.html.erb
@@ -1,1 +1,1 @@
-<%= field.truncate %>
+<%= field.truncate_stripped %>

--- a/app/views/fields/ckeditor/_show.html.erb
+++ b/app/views/fields/ckeditor/_show.html.erb
@@ -1,1 +1,1 @@
-<span class="preserve-whitespace"><%= field.data %></span>
+<%= field.to_html %>

--- a/lib/administrate/field/ckeditor.rb
+++ b/lib/administrate/field/ckeditor.rb
@@ -6,7 +6,6 @@ require "ckeditor"
 module Administrate
   module Field
     class Ckeditor < Administrate::Field::Text
-      VERSION = "0.0.2"
 
       class Engine < ::Rails::Engine
         Administrate::Engine.add_javascript "administrate-field-ckeditor/application"

--- a/lib/administrate/field/ckeditor.rb
+++ b/lib/administrate/field/ckeditor.rb
@@ -11,6 +11,22 @@ module Administrate
       class Engine < ::Rails::Engine
         Administrate::Engine.add_javascript "administrate-field-ckeditor/application"
       end
+      
+      include ActionView::Helpers::SanitizeHelper
+      include ActionView::Helpers::OutputSafetyHelper
+      
+      def truncate_stripped
+        strip_tags(data.to_s)[0..truncation_length]
+      end
+      
+      def to_html
+        raw(data.to_s)
+      end
+      
+      def ckeditor_options
+        options.fetch(:ckeditor, {})
+      end
+      
     end
   end
 end

--- a/spec/lib/administrate/field/ckeditor_spec.rb
+++ b/spec/lib/administrate/field/ckeditor_spec.rb
@@ -1,14 +1,25 @@
 require "administrate/field/ckeditor"
 
 describe Administrate::Field::Ckeditor do
+  
+  let(:page) { :show }
+  let(:data) { "<h1>Hello!</h1>\n<p>This is an exciting piece of data!</p>" }
+  subject { Administrate::Field::Ckeditor.new(:relation, "/a.jpg", page) }
+  before(:each) do
+    allow(subject).to receive(:data).and_return(data)
+    allow(subject).to receive(:truncation_length).and_return(10)
+  end
+    
   describe "#to_partial_path" do
     it "returns a partial based on the page being rendered" do
-      page = :show
-      field = Administrate::Field::Ckeditor.new(:relation, "/a.jpg", page)
-
-      path = field.to_partial_path
-
-      expect(path).to eq("/fields/ckeditor/#{page}")
+      expect(subject.to_partial_path).to eq("/fields/ckeditor/#{page}")
     end
   end
+  
+  describe '#truncate_stripped' do
+    it 'strips out HTML and truncates to the truncation length' do
+      expect(subject.truncate_stripped).to eq("Hello!\nThis")
+    end
+  end
+  
 end


### PR DESCRIPTION
Greetings from one UK-based consultancy to another! Thanks for putting together this gem.

I've made a handful of changes that hopefully you'll like:
1. On 'show' pages, the HTML of CkEditor elements is actually rendered as HTML, rather than the tags being visible.
2. On 'index' pages, the tags are stripped before the content is truncated.
3. You can pass a `:ckeditor` option to the field to apply any of CkEditor's options to the field (e.g. disabling some of the more annoying plugins, like filebrowser).

Let me know if you want any changes making!
