### PR TITLE
Support Administrate 0.3.0 and Rails 5.0.1

### DIFF
--- a/administrate-field-ckeditor.gemspec
+++ b/administrate-field-ckeditor.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name = "administrate-field-ckeditor"
-  gem.version = "0.0.3"
+  gem.version = "0.0.4"
   gem.authors = ["Rikki Pitt"]
   gem.email = ["rikkipitt@gmail.com"]
   gem.homepage = "https://github.com/jemcode/administrate-field-ckeditor"
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n")
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  gem.add_dependency "administrate", "~> 0.2.1"
+  gem.add_dependency "administrate", "~> 0.3.0"
   gem.add_dependency "rails", ">= 4.2"
   gem.add_dependency "ckeditor", "~> 4.1"
 end

--- a/lib/administrate/field/ckeditor.rb
+++ b/lib/administrate/field/ckeditor.rb
@@ -27,3 +27,17 @@ module Administrate
     end
   end
 end
+
+module Ckeditor
+  module Utils
+    class << self
+      alias_method :old_js_init_ckeditor, :js_init_ckeditor
+
+      def js_init_ckeditor(dom_id, replace)
+        %(document.addEventListener("DOMContentLoaded", function(event) {
+          #{old_js_init_ckeditor(dom_id, replace)}
+        });)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I ran into a few issues when installing this on the latest versions of Administrate/Rails.

This pull request represents a working gem at the specified versions.

In this PR:

* gemspec version updated
* Fix for CKEditor not working when the JS is loaded in the footer of the app (which was the default on my app)