### PR TITLE
Add support for 0.4

### DIFF
--- a/administrate-field-ckeditor.gemspec
+++ b/administrate-field-ckeditor.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n")
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  gem.add_dependency "administrate", "~> 0.3.0"
+  gem.add_dependency "administrate", ">= 0.3.0", "< 0.5"
   gem.add_dependency "rails", ">= 4.2", "< 5.1"
   gem.add_dependency "ckeditor", "~> 4.1"
 end


### PR DESCRIPTION
I've tested and everything seems to work with the newer version of administrate - it just needs the gemspec bumping.